### PR TITLE
feat: bump up 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didcomm-rs"
-version = "0.7.2"
+version = "0.8.0"
 authors = ["Ivan Temchenko <35359595i@gmail.com>", "Sebastian Wolfram <wulfraem@users.noreply.github.com>", "Sebastian Dechant <763247+S3bb1@users.noreply.github.com>"]
 edition = "2018"
 repository = "https://github.com/decentralized-identity/didcomm-rs"


### PR DESCRIPTION
# Why
- To version up after the fork as 0.8.0