### PR TITLE
update ddoresolver-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ k256 = { version = "0.9.4", optional = true, features = ["ecdsa", "sha256", "zer
 p256 = { version = "0.9.0", optional = true, features = ["ecdsa", "zeroize"] }
 ed25519-dalek = { version = "1.0", optional = true }
 hex = { version = "0.4.3", features = ["serde"] }
-ddoresolver-rs = { version = "0.4.2", default-features = false, features = ["didkey", "keriox"], optional = true }
+ddoresolver-rs = { version = "0.4.5", default-features = false, features = ["didkey", "keriox"], optional = true }
 x25519-dalek = "1.1"
 arrayref = "0.3"
 chrono = "0.4"


### PR DESCRIPTION
# Why

The version of zeroize is outdated, and there is a version conflict. I wanted to check if updating ddoresolver-rs, which is the dependency chain from didcomm-rs to zeroize, would update zeroize.