### PR TITLE
remove the unnecessary error type variant.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didcomm-rs"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Ivan Temchenko <35359595i@gmail.com>", "Sebastian Wolfram <wulfraem@users.noreply.github.com>", "Sebastian Dechant <763247+S3bb1@users.noreply.github.com>"]
 edition = "2018"
 repository = "https://github.com/decentralized-identity/didcomm-rs"

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,4 @@ pub enum Error {
     Base64DecodeError(#[from] base64_url::base64::DecodeError),
     #[error("invalid attachment{0}")]
     AttachmentError(String),
-    #[error(transparent)]
-    Other(Box<dyn std::error::Error>),
 }


### PR DESCRIPTION
## WHY

- `Box<dyn std::error::Error>` prevents the use of async/await.
- The `Other` variant is not used anywhere.

## NOTE

- The build was a failure from the beginning.